### PR TITLE
Allow private ips in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/ava-labs/icm-contracts
 go 1.22.10
 
 require (
-	github.com/ava-labs/avalanchego v1.12.1-0.20241210035517-714dfa0c3942
+	github.com/ava-labs/avalanchego v1.12.1-0.20241210172525-c7ebd8fbae88
 	github.com/supranational/blst v0.3.13 // indirect
 )
 
 require (
-	github.com/ava-labs/icm-services v1.4.1-0.20241210044204-a8fbd559ac77
+	github.com/ava-labs/icm-services v1.4.1-0.20241210180248-25d5c7f6c877
 	github.com/ava-labs/subnet-evm v0.6.13-0.20241205165027-6c98da796f35
 	github.com/ethereum/go-ethereum v1.13.14
 	github.com/onsi/ginkgo/v2 v2.22.0

--- a/go.sum
+++ b/go.sum
@@ -58,12 +58,12 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/avalanchego v1.12.1-0.20241210035517-714dfa0c3942 h1:eDSWDIaaMHNEAorxQqnA88S39zlgmQ26OKgWn5AaDJ0=
-github.com/ava-labs/avalanchego v1.12.1-0.20241210035517-714dfa0c3942/go.mod h1:yhD5dpZyStIVbxQ550EDi5w5SL7DQ/xGE6TIxosb7U0=
+github.com/ava-labs/avalanchego v1.12.1-0.20241210172525-c7ebd8fbae88 h1:tZdtOPFNblKZx+FmJOhqEfxUUscvPhcLHKGZO3BtQ6A=
+github.com/ava-labs/avalanchego v1.12.1-0.20241210172525-c7ebd8fbae88/go.mod h1:yhD5dpZyStIVbxQ550EDi5w5SL7DQ/xGE6TIxosb7U0=
 github.com/ava-labs/coreth v0.13.9-rc.1 h1:qIICpC/OZGYUP37QnLgIqqwGmxnLwLpZaUlqJNI85vU=
 github.com/ava-labs/coreth v0.13.9-rc.1/go.mod h1:7aMsRIo/3GBE44qWZMjnfqdqfcfZ5yShTTm2LObLaYo=
-github.com/ava-labs/icm-services v1.4.1-0.20241210044204-a8fbd559ac77 h1:n1BXCUoLmDhZ5pKgoZ9Fb8+q4DOCBuLVKzxI/fEP6O0=
-github.com/ava-labs/icm-services v1.4.1-0.20241210044204-a8fbd559ac77/go.mod h1:GVuxwUIXHt9vz/knNTWJBjMWJbGwQ4vuEuEtBVHNYCw=
+github.com/ava-labs/icm-services v1.4.1-0.20241210180248-25d5c7f6c877 h1:rQcSLYmGWJGDVM4Iq1JnxgFVI4Sw+IJiQwGbg0Kw8Gw=
+github.com/ava-labs/icm-services v1.4.1-0.20241210180248-25d5c7f6c877/go.mod h1:IJz87lGsHh16fRh8H0Cv6g+BgZ/wNaAA4fFVkAAAPrc=
 github.com/ava-labs/subnet-evm v0.6.13-0.20241205165027-6c98da796f35 h1:CbXWon0fwGDEDCCiChx2VeIIwO3UML9+8OUTyNwPsxA=
 github.com/ava-labs/subnet-evm v0.6.13-0.20241205165027-6c98da796f35/go.mod h1:SfAF4jjYPkezKWShPY/T31WQdD/UHrDyqy0kxA0LE0w=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/tests/utils/chain.go
+++ b/tests/utils/chain.go
@@ -549,6 +549,7 @@ func NewSignatureAggregator(apiUri string, l1IDs []ids.ID) *aggregator.Signature
 		InfoAPI: &relayerConfig.APIConfig{
 			BaseURL: apiUri,
 		},
+		AllowPrivateIPs: true,
 	}
 	trackedL1s := set.NewSet[ids.ID](len(l1IDs))
 	trackedL1s.Add(l1IDs...)


### PR DESCRIPTION
## Why this should be merged
Unblocks https://github.com/ava-labs/icm-services/pull/580/files by explicitly allowing private IPs in the test environment.

## How this works

## How this was tested

## How is this documented