### PR TITLE
Relax audit warnings

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,4 +18,4 @@ Please use the most recently released version to perform testing and to validate
 
 ## Audit Reports
 
-All complete audit reports for `TeleporterMessenger` can be found in the [audits](./audits/) directory.
+All complete audit reports for the contracts in this repository can be found in the [audits](./audits/) directory.

--- a/audits/README.md
+++ b/audits/README.md
@@ -1,6 +1,6 @@
 # Audits
 
-Below is the list of most recent audit for contracts in this repo. Please check out __only__ listed audited versions for production code. Code used should be the final commit audited.
+Below is the list of most recent audit for each smart contract application in this repository. Please exercise caution when using code newer than the audited commit.
 
 See `audits/historical` for older audits. These audits may now be obsolete, and legacy code superseded by new versions are __not__ recommended for production deployments.
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -13,7 +13,4 @@ This repository is set up as a [Foundry](https://github.com/foundry-rs/foundry) 
 
 ## Audits
 
-In general, the contracts in this repository have been audited. Any unaudited contracts will be explicitly marked as such. Note that the `main` branch may contain unaudited code. Please check [here](../audits/README.md) for which versions of each contract have been audited.
-
-> [!CAUTION]
-> DO NOT USE UN-AUDITED CODE IN PRODUCTION!
+In general, the contracts in this repository have been audited. Any contracts that have not undergone at least one audit will be explicitly marked as such. Please note that audits capture the state of code at a point in time, and the code is subject to change in the meantime. Please check [here](../audits/README.md) for the full list of audits.

--- a/contracts/teleporter/README.md
+++ b/contracts/teleporter/README.md
@@ -87,9 +87,6 @@ Once sent on chain, ICM messages cannot be re-signed by a new validator set in s
 
 ## TeleporterMessenger Contract Deployment
 
-> [!CAUTION]
-> DO NOT USE UN-AUDITED CODE IN PRODUCTION!
-
 **Do not deploy the `TeleporterMessenger` contract using `forge create`**. The `TeleporterMessenger` contract must be deployed to the same contract address on every chain. To achieve this, the contract can be deployed using a static transaction that uses Nick's method as documented in [this guide](../..//utils/contract-deployment/README.md). Alternatively, if creating a new L1, the contract can be pre-allocated with the proper address and state in the new chain's [genesis file](https://docs.avax.network/build/subnet/upgrade/customize-a-subnet#setting-the-genesis-allocation).
 
 As an example, to include `TeleporterMessenger` `v1.0.0` in the genesis file, include the following values in the `alloc` settings, as documented at the link above. The `storage` values included below correspond to the two contract values that are initialized as part of the default constructor of `TeleporterMessenger`. These are the `ReentrancyGuard` values set in this [abstract contract](../utilities/ReentrancyGuards.sol). Future versions of `TeleporterMessenger` may require different storage value initializations.


### PR DESCRIPTION
## Why this should be merged
The current language around the audits that have been conducted on the code in this repo is overly restrictive. Moreover, in the case of the validator manager contracts, the audited commit is not compatible with the finalized ACP-77 specification and corresponding Avalanchego release. 

## How this works
Updates docs

## How this was tested
CI

## How is this documented
Updates docs