### PR TITLE
Relax OpenZeppelin upgrades plugin validation checks

### DIFF
--- a/contracts/validator-manager/ERC20TokenStakingManager.sol
+++ b/contracts/validator-manager/ERC20TokenStakingManager.sol
@@ -20,6 +20,7 @@ import {SafeERC20} from "@openzeppelin/contracts@5.0.2/token/ERC20/utils/SafeERC
  * @dev Implementation of the {IERC20TokenStakingManager} interface.
  *
  * @custom:security-contact https://github.com/ava-labs/icm-contracts/blob/main/SECURITY.md
+ * @custom:oz-upgrades-unsafe-allow constructor external-library-linking
  */
 contract ERC20TokenStakingManager is
     Initializable,

--- a/contracts/validator-manager/NativeTokenStakingManager.sol
+++ b/contracts/validator-manager/NativeTokenStakingManager.sol
@@ -20,6 +20,7 @@ import {Initializable} from
  * @dev Implementation of the {INativeTokenStakingManager} interface.
  *
  * @custom:security-contact https://github.com/ava-labs/icm-contracts/blob/main/SECURITY.md
+ * @custom:oz-upgrades-unsafe-allow constructor external-library-linking
  */
 contract NativeTokenStakingManager is
     Initializable,

--- a/contracts/validator-manager/PoAValidatorManager.sol
+++ b/contracts/validator-manager/PoAValidatorManager.sol
@@ -19,6 +19,7 @@ import {OwnableUpgradeable} from
  * @dev Implementation of the {IPoAValidatorManager} interface.
  *
  * @custom:security-contact https://github.com/ava-labs/icm-contracts/blob/main/SECURITY.md
+ * @custom:oz-upgrades-unsafe-allow constructor external-library-linking
  */
 contract PoAValidatorManager is IPoAValidatorManager, ValidatorManager, OwnableUpgradeable {
     constructor(ICMInitializable init) {


### PR DESCRIPTION
## Why this should be merged
Fixes #648 by allowing constructors and external library calls.

## How this works
Adds NatSpec comments to the upgradeable `validator-manager` contracts to bypass the `constructor` and `external-library-linking` validation rules.

## How this was tested
Ci

## How is this documented
N/A