### PR TITLE
filter non-teleporter major releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Release Teleporter
 on:
   push:
     tags:
-      - "v*.*.0"
+      - "teleporter-v[0-9].0.0"
 
 jobs:
   build_and_upload_artifacts:


### PR DESCRIPTION
## Why this should be merged

Supports prefix tags for the Teleporter release job. Fixes a bug where minor releases would have triggered a release. According to the [versioning docs](https://github.com/ava-labs/icm-contracts/blob/main/contracts/teleporter/README.md#a-note-on-versioning), release artifacts should only be generated on changes to the `TeleporterMessenger` bytecode, which should be reflected in a major release.

Matches:
- `teleporter-v1.0.0`

Filters:
- `validator-manager-v1.0.0`
- `teleporter-v1.1.0`
- `teleporter-v1.0.1`

## How this works

## How this was tested

## How is this documented