### PR TITLE
Update go to 1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/icm-contracts
 
-go 1.22.10
+go 1.23.6
 
 require (
 	github.com/ava-labs/avalanchego v1.12.2


### PR DESCRIPTION
## Why this should be merged
Go 1.24 has now been released

## How this works

## How this was tested

## How is this documented