### PR TITLE
Explicitly enable optimizer

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,8 @@ solc_version = '0.8.25'
 evm_version = 'shanghai'
 test = 'tests'
 bytecode_hash = "none"
+optimizer = true
+optimizer_runs = 200
 
 [fmt]
 line_length = 100


### PR DESCRIPTION
## Why this should be merged
Foundry v1.0 disables the optimizer by [default](https://book.getfoundry.sh/guides/v1.0-migration#solc-optimizer-disabled-by-default), whereas the fork we maintain keeps it enabled. To avoid confusion, this change explicitly enables the optimizer, along with the default solc `optimizer-runs=200` in `foundry.toml`.

## How this works
See above

## How this was tested
CI

## How is this documented
N/A