### PR TITLE
N-10 Potential Storage Collision

### DIFF
--- a/contracts/validator-manager/MigratingFromV1.md
+++ b/contracts/validator-manager/MigratingFromV1.md
@@ -1,6 +1,8 @@
 # Migrating From V1 Validator Manager Contracts
 
-The V1 Validator Manager contracts are implemented as a single deployed contract consisting of multiple contracts related through inheritance. The V2 Validator Manager, on the other hand, may be consist of multiple deployed contracts that interact via external function calls. 
+The V1 Validator Manager contracts are implemented as a single deployed contract consisting of multiple contracts related through inheritance. The V2 Validator Manager, on the other hand, may be consist of multiple deployed contracts that interact via external function calls.
+
+> Note: This guide only applies to validator manager contracts at or above [validator-manager-v1.0.0](https://github.com/ava-labs/icm-contracts/releases/tag/validator-manager-v1.0.0). Contracts at commits before then must use other methods to convert to V2.
 
 ## Migrating Proof-of-Authority
 


### PR DESCRIPTION
## Why this should be merged

The [ValidatorManagerStorage struct](https://github.com/ava-labs/icm-contracts/blob/8a8f78dcda0b0af60c6fb1762f7927351357d645/contracts/validator-manager/ValidatorManager.sol#L70-L89) has been updated to include a modified version of the [ValidatorChurnPeriod struct](https://github.com/ava-labs/icm-contracts/blob/8a8f78dcda0b0af60c6fb1762f7927351357d645/contracts/validator-manager/ValidatorManager.sol#L78). In the previous version, ValidatorChurnPeriod [occupied](https://github.com/ava-labs/icm-contracts/blob/93920df605e7974bc4a21e8864b8181de402b5ad/contracts/validator-manager/interfaces/IValidatorManager.sol#L45-L50) 4 storage slots. On the other hand, the current version [occupies](https://github.com/ava-labs/icm-contracts/blob/8a8f78dcda0b0af60c6fb1762f7927351357d645/contracts/validator-manager/ValidatorManager.sol#L31-L36) 2 storage slots, effectively shifting the layout of subsequent storage variables in the ValidatorManagerStorage struct upward by 2 slots.

This change introduces a risk of storage collision in legacy instances of the ValidatorManager contract, which might be upgraded via the [migrateFromV1 function](https://github.com/ava-labs/icm-contracts/blob/8a8f78dcda0b0af60c6fb1762f7927351357d645/contracts/validator-manager/ValidatorManager.sol#L159-L182), as described in the [documentation](https://github.com/ava-labs/icm-contracts/blob/8a8f78dcda0b0af60c6fb1762f7927351357d645/contracts/validator-manager/MigratingFromV1.md#L1-L2). However, it has been confirmed that all known deployed instances are using [validator-manager-v1.0.0](https://github.com/ava-labs/icm-contracts/blob/validator-manager-v1.0.0/contracts/validator-manager/interfaces/IValidatorManager.sol#L45), which includes the updated layout of the ValidatorChurnPeriod struct. As a result, the risk of storage collision is significantly reduced under the current deployment landscape.

Commits prior to `validator-manager-v1.0.0` are not supported for migration to v2. This PR documents this explicitly.

## How this works

## How this was tested

## How is this documented

Documents v1->v2 compatibility requirements