### PR TITLE
L-01 Validators May Not Be Able to Exit Due to Churn Limits

### DIFF
--- a/contracts/validator-manager/README.md
+++ b/contracts/validator-manager/README.md
@@ -159,9 +159,13 @@ Validator exit is initiated with a call to `ValidatorManager.initiateValidatorRe
 
 ### PoS
 
-Similar to the validator registration flow, PoS validator removal is the same as the PoA case apply, with the only difference being that `StakingManager.initiateValidatorRemoval` and `StakingManager.completeValidatorRemoval` must be called instead.
+PoS validator removal follows the same flow as the PoA case, except that `StakingManager.initiateValidatorRemoval` and `StakingManager.completeValidatorRemoval` must be called instead.
 
-A [`ValidationUptimeMessage`](./UptimeMessageSpec.md) Warp message may optionally be provided in the call to `StakingManager.initiateValidatorRemoval` in order to calculate the staking rewards; otherwise the latest received uptime will be used (see [(PoS only) Submit and Uptime Proof](#pos-only-submit-an-uptime-proof)). This proof may be requested directly from the L1 validators, which will provide it in a `ValidationUptimeMessage` Warp message. If the uptime is not sufficient to earn validation rewards, the call to `initiateValidatorRemoval` will fail. `forceInitiateValidatorRemoval` acts the same as `initiateValidatorRemoval`, but bypasses the uptime-based rewards check. Once `initiateValidatorRemoval` or `forceInitiateValidatorRemoval` is called, staking rewards cease accruing for `StakingManagers`.
+There are two additional considerations:
+
+- A [`ValidationUptimeMessage`](./UptimeMessageSpec.md) Warp message may optionally be provided in the call to `StakingManager.initiateValidatorRemoval` in order to calculate the staking rewards; otherwise the latest received uptime will be used (see [(PoS only) Submit and Uptime Proof](#pos-only-submit-an-uptime-proof)). This proof may be requested directly from the L1 validators, which will provide it in a `ValidationUptimeMessage` Warp message. If the uptime is not sufficient to earn validation rewards, the call to `initiateValidatorRemoval` will fail. `forceInitiateValidatorRemoval` acts the same as `initiateValidatorRemoval`, but bypasses the uptime-based rewards check. Once `initiateValidatorRemoval` or `forceInitiateValidatorRemoval` is called, staking rewards cease accruing for `StakingManagers`.
+
+- Unlike with PoA, PoS validators are not able to decrease their weight. This can lead to a scenario in which a PoS validator manager with a high proportion of the L1's weight is not able to exit the validator set due to churn restrictions. Additional validators or delegators will need to first be registered to more evenly distribute weight across the L1's validator set.
 
 Once acknowledgement from the P-Chain has been received via a call to  `StakingManager.completeValidatorRemoval`, staking rewards are disbursed and stake is returned.
 


### PR DESCRIPTION
## Why this should be merged

The [_initiateValidatorRemoval function](https://github.com/ava-labs/icm-contracts/blob/8a8f78dcda0b0af60c6fb1762f7927351357d645/contracts/validator-manager/ValidatorManager.sol#L533) of the ValidatorManager contract updates the entire weight of the validator to 0. In the specific scenario where a validator's weight is higher than the maximum churn percentage of the L1 total validator weight, the transaction would revert due to churn limits being exceeded as per [this check](https://github.com/ava-labs/icm-contracts/blob/8a8f78dcda0b0af60c6fb1762f7927351357d645/contracts/validator-manager/ValidatorManager.sol#L733).

A validator with a weight higher than churn limits, trying to exit and unstake using [initiateValidatorRemoval function](https://github.com/ava-labs/icm-contracts/blob/8a8f78dcda0b0af60c6fb1762f7927351357d645/contracts/validator-manager/StakingManager.sol#L232) in the StakingManager contract, will not succeed. This validator may have to wait until new validators or delegators join the network such that its own weight is below the churn limits. Only after this may the validator be able to call initiateValidatorRemoval again and subsequently [call completeValidatorRemoval](https://github.com/ava-labs/icm-contracts/blob/8a8f78dcda0b0af60c6fb1762f7927351357d645/contracts/validator-manager/StakingManager.sol#L405) to withdraw its stake.

Furthermore, if the L1 only contains a small amount of validators and no new validators are joining the network, there could be a scenario where multiple validators with a weight higher than the churn limits may not be able to exit at all and their funds would be stuck in the StakingManager contract. Especially, if the L1 ValidatorManager and StakingManager contracts are residing on the C-Chain rather than on a chain that the L1 validators are validating. In this specific case, despite the validators having control of the chain validated by the L1, their staking funds may get stuck in the StakingManager contract that is on the C-Chain. Moreover, there will be always some dust weight present in the StakingManager contract [due to this check](https://github.com/ava-labs/icm-contracts/blob/8a8f78dcda0b0af60c6fb1762f7927351357d645/contracts/validator-manager/ValidatorManager.sol#L744-L746), belonging to either the validators or the delegators.

## How this works

## How this was tested

## How is this documented

Documents this scenario as a known edge case.