### PR TITLE
updated link for remote content used in Builder-hub docs

### DIFF
--- a/contracts/teleporter/README.md
+++ b/contracts/teleporter/README.md
@@ -14,7 +14,7 @@
 - [Upgradability](#upgradability)
 - [Deploy TeleporterMessenger to an L1](#deploy-teleportermessenger-to-an-avalanche-l1)
 - [Deploy TeleporterRegistry to an L1](#deploy-teleporterregistry-to-an-avalanche-l1)
-- [Verify a Deployment of TeleporterMessenger](#verify-a-deployment-of-teleporterMessenger)
+- [Verify a Deployment of TeleporterMessenger](#verify-a-deployment-of-teleportermessenger)
 
 ## Overview
 

--- a/contracts/validator-manager/README.md
+++ b/contracts/validator-manager/README.md
@@ -75,7 +75,7 @@ The contracts in this directory are only useful to L1s that have been converted 
 
 The validator manager system consists of a `ValidatorManager`, and one of `NativeTokenStakingManager`, `ERC20TokenStakingManager`, or `PoAManager`. `ValidatorManager` is `Ownable`, and its owner should be set to the address of the other contract.
 
-All of these are implemented as [upgradeable](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/main/contracts/proxy/utils/Initializable.sol#L56) contracts. There are numerous [guides](https://blog.chain.link/upgradable-smart-contracts/) for deploying upgradeable smart contracts, but the general steps are as follows:
+All of these are implemented as [upgradeable](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/3d6a15108b50491ec3c51c03b32802c33e092a0f/contracts/proxy/utils/Initializable.sol#L56) contracts. There are numerous [guides](https://blog.chain.link/upgradable-smart-contracts/) for deploying upgradeable smart contracts, but the general steps are as follows:
 
 1. Deploy the implementation contract
 2. Deploy the proxy contract


### PR DESCRIPTION
## Why this should be merged

Updated link

## How this works

Previous link was returning a 404

## How this was tested

## How is this documented