### PR TITLE
Ignore most new solhint rules

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -37,6 +37,14 @@
       5
     ],
     "one-contract-per-file": "off",
-    "import-path-check": "off"
+    "import-path-check": "off",
+    "gas-calldata-parameters": "off",
+    "use-natspec": "off",
+    "function-max-lines": "off",
+    "gas-indexed-events": "off",
+    "gas-increment-by-one": "off",
+    "gas-struct-packing": "off",
+    "gas-small-strings": "off",
+    "gas-strict-inequalities": "off"
   }
 }

--- a/contracts/ictt/tests/TokenRemoteTests.t.sol
+++ b/contracts/ictt/tests/TokenRemoteTests.t.sol
@@ -9,7 +9,6 @@ import {TeleporterMessageInput, TeleporterFeeInfo} from "@teleporter/ITeleporter
 import {TokenTransferrerTest} from "./TokenTransferrerTests.t.sol";
 import {TokenRemote, IWarpMessenger} from "../TokenRemote/TokenRemote.sol";
 import {TeleporterRegistry} from "@teleporter/registry/TeleporterRegistry.sol";
-import {SendTokensInput, SendAndCallInput} from "../interfaces/ITokenTransferrer.sol";
 import {ITeleporterMessenger} from "@teleporter/ITeleporterMessenger.sol";
 import {TokenScalingUtils} from "@utilities/TokenScalingUtils.sol";
 import {


### PR DESCRIPTION
## Why this should be merged
Solhint has a new major version `6.0.0`. This PR ignores all new rules added that we did not conform to except for `duplicated-imports` which was trivial to fix.

I've gone over the new rules - all the currently ignored rules don't seem worth it to me to conform to. 

## How this works

## How this was tested

## How is this documented