### PR TITLE
Reuse network for e2e test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ server.log
 # Forge documentation
 docs/
 coverage/
+
+TeleporterRegistryAddress.json
+ValidatorAddresses.json
+

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
 	github.com/pkg/errors v0.9.1
+	github.com/segmentio/encoding v0.5.1
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
@@ -118,6 +119,7 @@ require (
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -541,6 +541,10 @@ github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFo
 github.com/sanity-io/litter v1.5.1 h1:dwnrSypP6q56o3lFxTU+t2fwQ9A+U5qrXVO4Qg9KwVU=
 github.com/sanity-io/litter v1.5.1/go.mod h1:5Z71SvaYy5kcGtyglXOC9rrUi3c1E8CamFWjQsazTh0=
 github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.1 h1:LhmgXA5/alniiqfc4cYYrxF6DbUQ3m8MVz4/LQIU1mg=
+github.com/segmentio/encoding v0.5.1/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/tests/suites/governance/governance_suite_test.go
+++ b/tests/suites/governance/governance_suite_test.go
@@ -2,6 +2,7 @@ package governance_test
 
 import (
 	"context"
+	"flag"
 	"os"
 	"testing"
 	"time"
@@ -24,12 +25,17 @@ var (
 	e2eFlags             *e2e.FlagVars
 )
 
+func TestMain(m *testing.M) {
+	e2eFlags = e2e.RegisterFlags()
+	flag.Parse()
+	os.Exit(m.Run())
+}
+
 func TestGovernance(t *testing.T) {
 	if os.Getenv("RUN_E2E") == "" {
 		t.Skip("Environment variable RUN_E2E not set; skipping E2E tests")
 	}
 
-	e2eFlags = e2e.RegisterFlags()
 	RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "Governance e2e test")
 }

--- a/tests/suites/teleporter/teleporter_suite_test.go
+++ b/tests/suites/teleporter/teleporter_suite_test.go
@@ -5,6 +5,7 @@ package teleporter_test
 
 import (
 	"context"
+	"flag"
 	"os"
 	"testing"
 	"time"
@@ -12,7 +13,6 @@ import (
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/utils/units"
 	teleporterFlows "github.com/ava-labs/icm-contracts/tests/flows/teleporter"
-	registryFlows "github.com/ava-labs/icm-contracts/tests/flows/teleporter/registry"
 	"github.com/ava-labs/icm-contracts/tests/network"
 	"github.com/ava-labs/icm-contracts/tests/utils"
 	deploymentUtils "github.com/ava-labs/icm-contracts/utils/deployment-utils"
@@ -36,12 +36,17 @@ var (
 	e2eFlags             *e2e.FlagVars
 )
 
+func TestMain(m *testing.M) {
+	e2eFlags = e2e.RegisterFlags()
+	flag.Parse()
+	os.Exit(m.Run())
+}
+
 func TestTeleporter(t *testing.T) {
 	if os.Getenv("RUN_E2E") == "" {
 		t.Skip("Environment variable RUN_E2E not set; skipping E2E tests")
 	}
 
-	e2eFlags = e2e.RegisterFlags()
 	RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "Teleporter e2e test")
 }
@@ -97,31 +102,33 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	// Only need to deploy Teleporter on the C-Chain since it is included in the genesis of the l1 chains.
 	_, fundedKey := LocalNetworkInstance.GetFundedAccountInfo()
-	TeleporterInfo.DeployTeleporterMessenger(
-		ctx,
-		LocalNetworkInstance.GetPrimaryNetworkInfo(),
-		teleporterDeployerTransaction,
-		teleporterDeployerAddress,
-		teleporterContractAddress,
-		fundedKey,
-	)
+	if e2eFlags.NetworkDir() == "" {
+		TeleporterInfo.DeployTeleporterMessenger(
+			ctx,
+			LocalNetworkInstance.GetPrimaryNetworkInfo(),
+			teleporterDeployerTransaction,
+			teleporterDeployerAddress,
+			teleporterContractAddress,
+			fundedKey,
+		)
+
+		for _, subnet := range LocalNetworkInstance.GetL1Infos() {
+			// Choose weights such that we can test validator churn
+			LocalNetworkInstance.ConvertSubnet(
+				ctx,
+				subnet,
+				utils.PoAValidatorManager,
+				[]uint64{units.Schmeckle, units.Schmeckle, units.Schmeckle, units.Schmeckle, units.Schmeckle},
+				fundedKey,
+				false,
+			)
+		}
+	}
 
 	for _, l1 := range LocalNetworkInstance.GetAllL1Infos() {
 		TeleporterInfo.SetTeleporter(teleporterContractAddress, l1)
 		TeleporterInfo.InitializeBlockchainID(l1, fundedKey)
 		TeleporterInfo.DeployTeleporterRegistry(l1, fundedKey)
-	}
-
-	for _, subnet := range LocalNetworkInstance.GetL1Infos() {
-		// Choose weights such that we can test validator churn
-		LocalNetworkInstance.ConvertSubnet(
-			ctx,
-			subnet,
-			utils.PoAValidatorManager,
-			[]uint64{units.Schmeckle, units.Schmeckle, units.Schmeckle, units.Schmeckle, units.Schmeckle},
-			fundedKey,
-			false,
-		)
 	}
 
 	log.Info("Set up ginkgo before suite")
@@ -139,81 +146,81 @@ var _ = ginkgo.Describe("[Teleporter integration tests]", func() {
 		func() {
 			teleporterFlows.BasicSendReceive(LocalNetworkInstance, TeleporterInfo)
 		})
-	ginkgo.It("Deliver to the wrong chain",
-		ginkgo.Label(teleporterMessengerLabel),
-		func() {
-			teleporterFlows.DeliverToWrongChain(LocalNetworkInstance, TeleporterInfo)
-		})
-	ginkgo.It("Deliver to non-existent contract",
-		ginkgo.Label(teleporterMessengerLabel),
-		func() {
-			teleporterFlows.DeliverToNonExistentContract(LocalNetworkInstance, TeleporterInfo)
-		})
-	ginkgo.It("Retry successful execution",
-		ginkgo.Label(teleporterMessengerLabel),
-		func() {
-			teleporterFlows.RetrySuccessfulExecution(LocalNetworkInstance, TeleporterInfo)
-		})
-	ginkgo.It("Unallowed relayer",
-		ginkgo.Label(teleporterMessengerLabel),
-		func() {
-			teleporterFlows.UnallowedRelayer(LocalNetworkInstance, TeleporterInfo)
-		})
-	ginkgo.It("Relay message twice",
-		ginkgo.Label(teleporterMessengerLabel),
-		func() {
-			teleporterFlows.RelayMessageTwice(LocalNetworkInstance, TeleporterInfo)
-		})
-	ginkgo.It("Add additional fee amount",
-		ginkgo.Label(teleporterMessengerLabel),
-		func() {
-			teleporterFlows.AddFeeAmount(LocalNetworkInstance, TeleporterInfo)
-		})
-	ginkgo.It("Send specific receipts",
-		ginkgo.Label(teleporterMessengerLabel),
-		func() {
-			teleporterFlows.SendSpecificReceipts(LocalNetworkInstance, TeleporterInfo)
-		})
-	ginkgo.It("Insufficient gas",
-		ginkgo.Label(teleporterMessengerLabel),
-		func() {
-			teleporterFlows.InsufficientGas(LocalNetworkInstance, TeleporterInfo)
-		})
-	ginkgo.It("Resubmit altered message",
-		ginkgo.Label(teleporterMessengerLabel),
-		func() {
-			teleporterFlows.ResubmitAlteredMessage(LocalNetworkInstance, TeleporterInfo)
-		})
-	ginkgo.It("Calculate Teleporter message IDs",
-		ginkgo.Label(utilsLabel),
-		func() {
-			teleporterFlows.CalculateMessageID(LocalNetworkInstance, TeleporterInfo)
-		})
-	ginkgo.It("Relayer modifies message",
-		ginkgo.Label(teleporterMessengerLabel),
-		func() {
-			teleporterFlows.RelayerModifiesMessage(LocalNetworkInstance, TeleporterInfo)
-		})
-	ginkgo.It("Validator churn",
-		ginkgo.Label(teleporterMessengerLabel),
-		func() {
-			teleporterFlows.ValidatorChurn(LocalNetworkInstance, TeleporterInfo)
-		})
+	// ginkgo.It("Deliver to the wrong chain",
+	// 	ginkgo.Label(teleporterMessengerLabel),
+	// 	func() {
+	// 		teleporterFlows.DeliverToWrongChain(LocalNetworkInstance, TeleporterInfo)
+	// 	})
+	// ginkgo.It("Deliver to non-existent contract",
+	// 	ginkgo.Label(teleporterMessengerLabel),
+	// 	func() {
+	// 		teleporterFlows.DeliverToNonExistentContract(LocalNetworkInstance, TeleporterInfo)
+	// 	})
+	// ginkgo.It("Retry successful execution",
+	// 	ginkgo.Label(teleporterMessengerLabel),
+	// 	func() {
+	// 		teleporterFlows.RetrySuccessfulExecution(LocalNetworkInstance, TeleporterInfo)
+	// 	})
+	// ginkgo.It("Unallowed relayer",
+	// 	ginkgo.Label(teleporterMessengerLabel),
+	// 	func() {
+	// 		teleporterFlows.UnallowedRelayer(LocalNetworkInstance, TeleporterInfo)
+	// 	})
+	// ginkgo.It("Relay message twice",
+	// 	ginkgo.Label(teleporterMessengerLabel),
+	// 	func() {
+	// 		teleporterFlows.RelayMessageTwice(LocalNetworkInstance, TeleporterInfo)
+	// 	})
+	// ginkgo.It("Add additional fee amount",
+	// 	ginkgo.Label(teleporterMessengerLabel),
+	// 	func() {
+	// 		teleporterFlows.AddFeeAmount(LocalNetworkInstance, TeleporterInfo)
+	// 	})
+	// ginkgo.It("Send specific receipts",
+	// 	ginkgo.Label(teleporterMessengerLabel),
+	// 	func() {
+	// 		teleporterFlows.SendSpecificReceipts(LocalNetworkInstance, TeleporterInfo)
+	// 	})
+	// ginkgo.It("Insufficient gas",
+	// 	ginkgo.Label(teleporterMessengerLabel),
+	// 	func() {
+	// 		teleporterFlows.InsufficientGas(LocalNetworkInstance, TeleporterInfo)
+	// 	})
+	// ginkgo.It("Resubmit altered message",
+	// 	ginkgo.Label(teleporterMessengerLabel),
+	// 	func() {
+	// 		teleporterFlows.ResubmitAlteredMessage(LocalNetworkInstance, TeleporterInfo)
+	// 	})
+	// ginkgo.It("Calculate Teleporter message IDs",
+	// 	ginkgo.Label(utilsLabel),
+	// 	func() {
+	// 		teleporterFlows.CalculateMessageID(LocalNetworkInstance, TeleporterInfo)
+	// 	})
+	// ginkgo.It("Relayer modifies message",
+	// 	ginkgo.Label(teleporterMessengerLabel),
+	// 	func() {
+	// 		teleporterFlows.RelayerModifiesMessage(LocalNetworkInstance, TeleporterInfo)
+	// 	})
+	// ginkgo.It("Validator churn",
+	// 	ginkgo.Label(teleporterMessengerLabel),
+	// 	func() {
+	// 		teleporterFlows.ValidatorChurn(LocalNetworkInstance, TeleporterInfo)
+	// 	})
 
-	// Teleporter Registry tests
-	ginkgo.It("Teleporter registry",
-		ginkgo.Label(upgradabilityLabel),
-		func() {
-			registryFlows.TeleporterRegistry(LocalNetworkInstance, TeleporterInfo)
-		})
-	ginkgo.It("Check upgrade access",
-		ginkgo.Label(upgradabilityLabel),
-		func() {
-			registryFlows.CheckUpgradeAccess(LocalNetworkInstance, TeleporterInfo)
-		})
-	ginkgo.It("Pause and Unpause Teleporter",
-		ginkgo.Label(upgradabilityLabel),
-		func() {
-			registryFlows.PauseTeleporter(LocalNetworkInstance, TeleporterInfo)
-		})
+	// // Teleporter Registry tests
+	// ginkgo.It("Teleporter registry",
+	// 	ginkgo.Label(upgradabilityLabel),
+	// 	func() {
+	// 		registryFlows.TeleporterRegistry(LocalNetworkInstance, TeleporterInfo)
+	// 	})
+	// ginkgo.It("Check upgrade access",
+	// 	ginkgo.Label(upgradabilityLabel),
+	// 	func() {
+	// 		registryFlows.CheckUpgradeAccess(LocalNetworkInstance, TeleporterInfo)
+	// 	})
+	// ginkgo.It("Pause and Unpause Teleporter",
+	// 	ginkgo.Label(upgradabilityLabel),
+	// 	func() {
+	// 		registryFlows.PauseTeleporter(LocalNetworkInstance, TeleporterInfo)
+	// 	})
 })

--- a/tests/suites/teleporter/teleporter_suite_test.go
+++ b/tests/suites/teleporter/teleporter_suite_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/tests/fixture/e2e"
 	"github.com/ava-labs/avalanchego/utils/units"
 	teleporterFlows "github.com/ava-labs/icm-contracts/tests/flows/teleporter"
+	registryFlows "github.com/ava-labs/icm-contracts/tests/flows/teleporter/registry"
 	"github.com/ava-labs/icm-contracts/tests/network"
 	"github.com/ava-labs/icm-contracts/tests/utils"
 	deploymentUtils "github.com/ava-labs/icm-contracts/utils/deployment-utils"
@@ -28,6 +29,9 @@ const (
 	teleporterMessengerLabel = "TeleporterMessenger"
 	upgradabilityLabel       = "upgradability"
 	utilsLabel               = "utils"
+
+	teleporterRegistryAddressFile = "TeleporterRegistryAddress.json"
+	validatorAddressesFile        = "ValidatorAddresses.json"
 )
 
 var (
@@ -123,12 +127,28 @@ var _ = ginkgo.BeforeSuite(func() {
 				false,
 			)
 		}
-	}
 
-	for _, l1 := range LocalNetworkInstance.GetAllL1Infos() {
-		TeleporterInfo.SetTeleporter(teleporterContractAddress, l1)
-		TeleporterInfo.InitializeBlockchainID(l1, fundedKey)
-		TeleporterInfo.DeployTeleporterRegistry(l1, fundedKey)
+		for _, l1 := range LocalNetworkInstance.GetAllL1Infos() {
+			TeleporterInfo.SetTeleporter(teleporterContractAddress, l1)
+			TeleporterInfo.InitializeBlockchainID(l1, fundedKey)
+			TeleporterInfo.DeployTeleporterRegistry(l1, fundedKey)
+		}
+
+		// Save the Teleporter registry address and validator addresses to files
+		utils.SaveRegistyAddress(TeleporterInfo, teleporterRegistryAddressFile)
+
+		LocalNetworkInstance.SaveValidatorAddress(validatorAddressesFile)
+	} else {
+		// Read the Teleporter registry address from the file
+		utils.SetTeleporterInfoFromFile(
+			teleporterRegistryAddressFile,
+			teleporterContractAddress,
+			TeleporterInfo,
+			LocalNetworkInstance.GetAllL1Infos(),
+		)
+
+		// Read the validator addresses from the file
+		LocalNetworkInstance.SetValidatorAddressFromFile(validatorAddressesFile)
 	}
 
 	log.Info("Set up ginkgo before suite")
@@ -146,81 +166,81 @@ var _ = ginkgo.Describe("[Teleporter integration tests]", func() {
 		func() {
 			teleporterFlows.BasicSendReceive(LocalNetworkInstance, TeleporterInfo)
 		})
-	// ginkgo.It("Deliver to the wrong chain",
-	// 	ginkgo.Label(teleporterMessengerLabel),
-	// 	func() {
-	// 		teleporterFlows.DeliverToWrongChain(LocalNetworkInstance, TeleporterInfo)
-	// 	})
-	// ginkgo.It("Deliver to non-existent contract",
-	// 	ginkgo.Label(teleporterMessengerLabel),
-	// 	func() {
-	// 		teleporterFlows.DeliverToNonExistentContract(LocalNetworkInstance, TeleporterInfo)
-	// 	})
-	// ginkgo.It("Retry successful execution",
-	// 	ginkgo.Label(teleporterMessengerLabel),
-	// 	func() {
-	// 		teleporterFlows.RetrySuccessfulExecution(LocalNetworkInstance, TeleporterInfo)
-	// 	})
-	// ginkgo.It("Unallowed relayer",
-	// 	ginkgo.Label(teleporterMessengerLabel),
-	// 	func() {
-	// 		teleporterFlows.UnallowedRelayer(LocalNetworkInstance, TeleporterInfo)
-	// 	})
-	// ginkgo.It("Relay message twice",
-	// 	ginkgo.Label(teleporterMessengerLabel),
-	// 	func() {
-	// 		teleporterFlows.RelayMessageTwice(LocalNetworkInstance, TeleporterInfo)
-	// 	})
-	// ginkgo.It("Add additional fee amount",
-	// 	ginkgo.Label(teleporterMessengerLabel),
-	// 	func() {
-	// 		teleporterFlows.AddFeeAmount(LocalNetworkInstance, TeleporterInfo)
-	// 	})
-	// ginkgo.It("Send specific receipts",
-	// 	ginkgo.Label(teleporterMessengerLabel),
-	// 	func() {
-	// 		teleporterFlows.SendSpecificReceipts(LocalNetworkInstance, TeleporterInfo)
-	// 	})
-	// ginkgo.It("Insufficient gas",
-	// 	ginkgo.Label(teleporterMessengerLabel),
-	// 	func() {
-	// 		teleporterFlows.InsufficientGas(LocalNetworkInstance, TeleporterInfo)
-	// 	})
-	// ginkgo.It("Resubmit altered message",
-	// 	ginkgo.Label(teleporterMessengerLabel),
-	// 	func() {
-	// 		teleporterFlows.ResubmitAlteredMessage(LocalNetworkInstance, TeleporterInfo)
-	// 	})
-	// ginkgo.It("Calculate Teleporter message IDs",
-	// 	ginkgo.Label(utilsLabel),
-	// 	func() {
-	// 		teleporterFlows.CalculateMessageID(LocalNetworkInstance, TeleporterInfo)
-	// 	})
-	// ginkgo.It("Relayer modifies message",
-	// 	ginkgo.Label(teleporterMessengerLabel),
-	// 	func() {
-	// 		teleporterFlows.RelayerModifiesMessage(LocalNetworkInstance, TeleporterInfo)
-	// 	})
-	// ginkgo.It("Validator churn",
-	// 	ginkgo.Label(teleporterMessengerLabel),
-	// 	func() {
-	// 		teleporterFlows.ValidatorChurn(LocalNetworkInstance, TeleporterInfo)
-	// 	})
+	ginkgo.It("Deliver to the wrong chain",
+		ginkgo.Label(teleporterMessengerLabel),
+		func() {
+			teleporterFlows.DeliverToWrongChain(LocalNetworkInstance, TeleporterInfo)
+		})
+	ginkgo.It("Deliver to non-existent contract",
+		ginkgo.Label(teleporterMessengerLabel),
+		func() {
+			teleporterFlows.DeliverToNonExistentContract(LocalNetworkInstance, TeleporterInfo)
+		})
+	ginkgo.It("Retry successful execution",
+		ginkgo.Label(teleporterMessengerLabel),
+		func() {
+			teleporterFlows.RetrySuccessfulExecution(LocalNetworkInstance, TeleporterInfo)
+		})
+	ginkgo.It("Unallowed relayer",
+		ginkgo.Label(teleporterMessengerLabel),
+		func() {
+			teleporterFlows.UnallowedRelayer(LocalNetworkInstance, TeleporterInfo)
+		})
+	ginkgo.It("Relay message twice",
+		ginkgo.Label(teleporterMessengerLabel),
+		func() {
+			teleporterFlows.RelayMessageTwice(LocalNetworkInstance, TeleporterInfo)
+		})
+	ginkgo.It("Add additional fee amount",
+		ginkgo.Label(teleporterMessengerLabel),
+		func() {
+			teleporterFlows.AddFeeAmount(LocalNetworkInstance, TeleporterInfo)
+		})
+	ginkgo.It("Send specific receipts",
+		ginkgo.Label(teleporterMessengerLabel),
+		func() {
+			teleporterFlows.SendSpecificReceipts(LocalNetworkInstance, TeleporterInfo)
+		})
+	ginkgo.It("Insufficient gas",
+		ginkgo.Label(teleporterMessengerLabel),
+		func() {
+			teleporterFlows.InsufficientGas(LocalNetworkInstance, TeleporterInfo)
+		})
+	ginkgo.It("Resubmit altered message",
+		ginkgo.Label(teleporterMessengerLabel),
+		func() {
+			teleporterFlows.ResubmitAlteredMessage(LocalNetworkInstance, TeleporterInfo)
+		})
+	ginkgo.It("Calculate Teleporter message IDs",
+		ginkgo.Label(utilsLabel),
+		func() {
+			teleporterFlows.CalculateMessageID(LocalNetworkInstance, TeleporterInfo)
+		})
+	ginkgo.It("Relayer modifies message",
+		ginkgo.Label(teleporterMessengerLabel),
+		func() {
+			teleporterFlows.RelayerModifiesMessage(LocalNetworkInstance, TeleporterInfo)
+		})
+	ginkgo.It("Validator churn",
+		ginkgo.Label(teleporterMessengerLabel),
+		func() {
+			teleporterFlows.ValidatorChurn(LocalNetworkInstance, TeleporterInfo)
+		})
 
-	// // Teleporter Registry tests
-	// ginkgo.It("Teleporter registry",
-	// 	ginkgo.Label(upgradabilityLabel),
-	// 	func() {
-	// 		registryFlows.TeleporterRegistry(LocalNetworkInstance, TeleporterInfo)
-	// 	})
-	// ginkgo.It("Check upgrade access",
-	// 	ginkgo.Label(upgradabilityLabel),
-	// 	func() {
-	// 		registryFlows.CheckUpgradeAccess(LocalNetworkInstance, TeleporterInfo)
-	// 	})
-	// ginkgo.It("Pause and Unpause Teleporter",
-	// 	ginkgo.Label(upgradabilityLabel),
-	// 	func() {
-	// 		registryFlows.PauseTeleporter(LocalNetworkInstance, TeleporterInfo)
-	// 	})
+	// Teleporter Registry tests
+	ginkgo.It("Teleporter registry",
+		ginkgo.Label(upgradabilityLabel),
+		func() {
+			registryFlows.TeleporterRegistry(LocalNetworkInstance, TeleporterInfo)
+		})
+	ginkgo.It("Check upgrade access",
+		ginkgo.Label(upgradabilityLabel),
+		func() {
+			registryFlows.CheckUpgradeAccess(LocalNetworkInstance, TeleporterInfo)
+		})
+	ginkgo.It("Pause and Unpause Teleporter",
+		ginkgo.Label(upgradabilityLabel),
+		func() {
+			registryFlows.PauseTeleporter(LocalNetworkInstance, TeleporterInfo)
+		})
 })


### PR DESCRIPTION
## Why this should be merged
- Reuse network for e2e tests. It saves time to setup e2e tests.

## How this works
- The network info is persisted in a directory. When running the e2e tests, we load the network from the directory and reuse the network.
- To reuse the network:
```bash
./scripts/e2e_test.sh --components teleporter --network-dir <network directory>
```

## How this was tested
- e2e tests

## How is this documented