### PR TITLE
Pass balances as a parameter to ConvertSubnet in e2e tests

### DIFF
--- a/tests/flows/validator-manager/delegator_inactive_validator.go
+++ b/tests/flows/validator-manager/delegator_inactive_validator.go
@@ -34,11 +34,13 @@ func RemoveDelegatorInactiveValidator(network *localnetwork.LocalNetwork) {
 
 	ctx := context.Background()
 
+	balance := 100 * units.Avax
 	nodes, initialValidationIDs := network.ConvertSubnet(
 		ctx,
 		l1AInfo,
 		utils.ERC20TokenStakingManager,
 		[]uint64{units.Schmeckle, 1000 * units.Schmeckle}, // Choose weights to avoid validator churn limits
+		[]uint64{balance, balance},
 		fundedKey,
 		false,
 	)

--- a/tests/flows/validator-manager/erc20_token_staking.go
+++ b/tests/flows/validator-manager/erc20_token_staking.go
@@ -42,11 +42,13 @@ func ERC20TokenStakingManager(network *localnetwork.LocalNetwork) {
 
 	ctx := context.Background()
 
+	balance := 100 * units.Avax
 	nodes, initialValidationIDs := network.ConvertSubnet(
 		ctx,
 		l1AInfo,
 		utils.ERC20TokenStakingManager,
 		[]uint64{units.Schmeckle, 1000 * units.Schmeckle}, // Choose weights to avoid validator churn limits
+		[]uint64{balance, balance},
 		fundedKey,
 		false,
 	)

--- a/tests/flows/validator-manager/native_token_staking.go
+++ b/tests/flows/validator-manager/native_token_staking.go
@@ -41,11 +41,13 @@ func NativeTokenStakingManager(network *localnetwork.LocalNetwork) {
 
 	ctx := context.Background()
 
+	balance := 100 * units.Avax
 	nodes, initialValidationIDs := network.ConvertSubnet(
 		ctx,
 		l1AInfo,
 		utils.NativeTokenStakingManager,
 		[]uint64{units.Schmeckle, 1000 * units.Schmeckle}, // Choose weights to avoid validator churn limits
+		[]uint64{balance, balance},
 		fundedKey,
 		false,
 	)

--- a/tests/flows/validator-manager/poa_to_pos.go
+++ b/tests/flows/validator-manager/poa_to_pos.go
@@ -61,12 +61,14 @@ func PoAMigrationToPoS(network *localnetwork.LocalNetwork) {
 		fundAmount,
 	)
 
+	balance := 100 * units.Avax
 	// Deploy PoAManager
 	nodes, initialValidationIDs := network.ConvertSubnet(
 		ctx,
 		l1AInfo,
 		utils.PoAValidatorManager,
 		[]uint64{units.Schmeckle, 1000 * units.Schmeckle}, // Choose weights to avoid validator churn limits
+		[]uint64{balance, balance},
 		ownerKey,
 		false,
 	)

--- a/tests/network/network.go
+++ b/tests/network/network.go
@@ -192,7 +192,7 @@ func (n *LocalNetwork) ConvertSubnet(
 	senderKey *ecdsa.PrivateKey,
 	proxy bool,
 ) ([]utils.Node, []ids.ID) {
-	Expect(len(weights)).Should(BeNumerically("==", len(balances)))
+	Expect(len(weights)).Should(Equal(len(balances)))
 	goLog.Println("Converting l1", l1.SubnetID)
 	cChainInfo := n.GetPrimaryNetworkInfo()
 	pClient := platformvm.NewClient(cChainInfo.NodeURIs[0])

--- a/tests/network/network.go
+++ b/tests/network/network.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	warpMessage "github.com/ava-labs/avalanchego/vms/platformvm/warp/message"
@@ -189,9 +188,11 @@ func (n *LocalNetwork) ConvertSubnet(
 	l1 interfaces.L1TestInfo,
 	managerType utils.ValidatorManagerConcreteType,
 	weights []uint64,
+	balances []uint64,
 	senderKey *ecdsa.PrivateKey,
 	proxy bool,
 ) ([]utils.Node, []ids.ID) {
+	Expect(len(weights)).Should(BeNumerically("==", len(balances)))
 	goLog.Println("Converting l1", l1.SubnetID)
 	cChainInfo := n.GetPrimaryNetworkInfo()
 	pClient := platformvm.NewClient(cChainInfo.NodeURIs[0])
@@ -268,7 +269,7 @@ func (n *LocalNetwork) ConvertSubnet(
 		vdrs[i] = &txs.ConvertSubnetToL1Validator{
 			NodeID:  node.NodeID.Bytes(),
 			Weight:  weights[i],
-			Balance: units.Avax * 100,
+			Balance: balances[i],
 			Signer:  *signer,
 			RemainingBalanceOwner: warpMessage.PChainOwner{
 				Threshold: 1,

--- a/tests/suites/teleporter/teleporter_suite_test.go
+++ b/tests/suites/teleporter/teleporter_suite_test.go
@@ -112,6 +112,7 @@ var _ = ginkgo.BeforeSuite(func() {
 		TeleporterInfo.DeployTeleporterRegistry(l1, fundedKey)
 	}
 
+	balance := 100 * units.Avax
 	for _, subnet := range LocalNetworkInstance.GetL1Infos() {
 		// Choose weights such that we can test validator churn
 		LocalNetworkInstance.ConvertSubnet(
@@ -119,6 +120,7 @@ var _ = ginkgo.BeforeSuite(func() {
 			subnet,
 			utils.PoAValidatorManager,
 			[]uint64{units.Schmeckle, units.Schmeckle, units.Schmeckle, units.Schmeckle, units.Schmeckle},
+			[]uint64{balance, balance, balance, balance, balance},
 			fundedKey,
 			false,
 		)


### PR DESCRIPTION
## Why this should be merged
This PR refactors the ConvertSubnet function and related logic to accept a balances parameter, allowing explicit control over the initial balances assigned to validators during subnet conversion. Previously, only weights were passed, and balances were set to a default value. By passing balances as an argument, tests and deployments can now specify the exact initial balance for each validator, improving flexibility and correctness for scenarios that require custom validator funding.

This change makes it possible to test scenarios with underfunded validators, which was previously not feasible. This is useful for verifying contract and system behavior when validators do not have sufficient balance.

## How this works

## How this was tested
E2E tests

## How is this documented